### PR TITLE
Adjust line height for GoogleChrome

### DIFF
--- a/web/vim.css
+++ b/web/vim.css
@@ -21,6 +21,9 @@
   box-shadow: 0px 1px 1px rgba(0, 0, 0, 0.075) inset, 0px 0px 8px rgba(102, 175, 233, 0.6);
   font: 12px monospace;
 }
+.vimjs-line{
+  line-height: 15px;
+}
 .vimjs-line span { 
   white-space: pre; 
   border:0;


### PR DESCRIPTION
Window height is 630px and there are 42 lines, include cmdline.
Each lines' height should be 15px but it's not in GoogleChrome.

This will fix that.

![lh](https://f.cloud.github.com/assets/377137/1734122/1d1979f2-6342-11e3-8d40-88c59d785878.png)
