### PR TITLE
Add multibyte support, using builtin emscripten UTF8 functions.

### DIFF
--- a/web/usr/local/share/vim/vimrc
+++ b/web/usr/local/share/vim/vimrc
@@ -55,6 +55,8 @@ set wildmenu
 set tabstop=4
 set expandtab
 set nocompatible
+set encoding=utf8
+set termencoding=utf8
 set fileencodings=utf8
 set backspace=indent,eol,start
 set wildmode=longest,list,full

--- a/web/vim_lib.js
+++ b/web/vim_lib.js
@@ -82,17 +82,26 @@ var LibraryVIM = {
       if(e.altKey) modifiers |= 0x08;
       if(e.metaKey) modifiers |= 0x10;
 
-      var handled = false;
       if(charCode == 0) {
         var special = vimjs.special_keys[keyCode];
         if(special !== undefined) {
-          vimjs.gui_web_handle_key(charCode || keyCode, modifiers, special.charCodeAt(0), special.charCodeAt(1));
-          handled = true;
-        } 
+          vimjs.gui_web_handle_key(keyCode, modifiers, special.charCodeAt(0), special.charCodeAt(1));
+        } else {
+          vimjs.gui_web_handle_key(keyCode, modifiers, 0, 0);
+        }
+      } else {
+        var MAX_UTF8_BYTES = 6;
+        var chars = new Uint8Array(MAX_UTF8_BYTES + 1); // null-terminated
+        var charLen = stringToUTF8Array(String.fromCharCode(charCode), chars, 0, MAX_UTF8_BYTES);
+        if (charLen == 1) {
+          vimjs.gui_web_handle_key(chars[0], 0, 0, 0);
+        } else {
+          // no modifers for UTF-8, should be handled in chars already
+          for (var i = 0; i < charLen; i++) {
+            vimjs.gui_web_handle_key(chars[i], 0, 0, 0);
+          }
+        }
       }
-
-      if(!handled)
-        vimjs.gui_web_handle_key(charCode || keyCode, modifiers, 0, 0);
 
     },//VIMJS_FOLD_END
 
@@ -695,14 +704,24 @@ var LibraryVIM = {
       KeyEvent.DOM_VK_DELETE, // C
       KeyEvent.DOM_VK_PAGE_UP, // C
       KeyEvent.DOM_VK_PAGE_DOWN, // C
+      KeyEvent.DOM_VK_HOME, // C
+      KeyEvent.DOM_VK_END, // C
     ].forEach(function(k) {
       keys_to_intercept_upon_keydown[k] = 1;
+    });
+    var ctrl_keys_to_intercept_upon_keydown = {};
+    [
+      KeyEvent.DOM_VK_F,
+      KeyEvent.DOM_VK_B,
+    ].forEach(function(k) {
+      ctrl_keys_to_intercept_upon_keydown[k] = 1;
     });
 
     /* capture some special keys that won't trigger 'keypress' */
     document.addEventListener('keydown', function(e) {
       if (ignoreKeys()) return true;
-      if(e.keyCode in keys_to_intercept_upon_keydown)  {
+      if((e.keyCode in keys_to_intercept_upon_keydown) ||
+        (e.ctrlKey && (e.keyCode in ctrl_keys_to_intercept_upon_keydown)))  {
         e.preventDefault();
         vimjs.handle_key(0, e.keyCode, e);
       }
@@ -778,7 +797,15 @@ var LibraryVIM = {
   },
 
   vimjs_draw_string__deps: ['vimjs_clear_block'],
-  vimjs_draw_string: function(row, col, s, len, flags) {
+  vimjs_draw_string: function(row, col, s_ptr, len, flags) {
+    var byteArray = [];
+    for (var i = 0; i < len; i++) {
+      c = getValue(s_ptr + i, 'i8', true);
+      byteArray.push(c);
+    }
+    byteArray.push(0);
+    var s = UTF8ArrayToString(byteArray, 0);
+    len = s.length;
 
     // TODO: use macros for flag constants
     if(!(flags & 0x01)) {
@@ -787,8 +814,6 @@ var LibraryVIM = {
 
     var font = vimjs.font;
     if(flags & 0x02) font = 'bold ' + font;
-
-    s = Pointer_stringify(s, len);
 
     var ctx = vimjs.canvas_ctx;
 


### PR DESCRIPTION
It is disabled by default.
Fix $ to end of line, HOME, END, CTRL+F (forward) and CTRL+B (backward) on Chrome. Also tested on Firefox and IE.
Consistently use -Oz optimization across all stages of compilation: configure, make and link.
Remove 'handled' if.
Add exported functions to emterpreted version.
